### PR TITLE
fix warning

### DIFF
--- a/lib/slack_logger_backend/logger.ex
+++ b/lib/slack_logger_backend/logger.ex
@@ -84,7 +84,7 @@ defmodule SlackLoggerBackend.Logger do
   end
 
   defp send_event(event) do
-    Producer.add_event({get_url, event})
+    Producer.add_event({get_url(), event})
   end
 
 end


### PR DESCRIPTION
fix warning below
```
warning: variable "get_url" does not exist and is being expanded to "get_url()", please use parentheses to remove the ambiguity or change the variable name
  lib/slack_logger_backend/logger.ex:87
```
