### PR TITLE
Update logger.ex to allow config to use :slack_logger_backend

### DIFF
--- a/lib/slack_logger_backend/logger.ex
+++ b/lib/slack_logger_backend/logger.ex
@@ -30,7 +30,7 @@ defmodule SlackLoggerBackend.Logger do
 
   @doc false
   def handle_event({level, _pid, {_, message, _timestamp, detail}}, %{levels: []} = state) do
-    levels = case Application.get_env(SlackLoggerBackend, :levels) do
+    levels = case get_env(:levels) do
       nil ->
         @default_log_levels
       levels ->
@@ -63,7 +63,7 @@ defmodule SlackLoggerBackend.Logger do
   defp get_url do
     case System.get_env(@env_webhook) do
       nil ->
-        Application.get_env(SlackLoggerBackend, :slack)[:url]
+        get_env(:slack)[:url]
       url ->
         url
     end
@@ -85,6 +85,10 @@ defmodule SlackLoggerBackend.Logger do
 
   defp send_event(event) do
     Producer.add_event({get_url(), event})
+  end
+
+  defp get_env(key, default \\ nil) do
+    Application.get_env(SlackLoggerBackend, key) || Application.get_env(:slack_logger_backend, key) || default
   end
 
 end

--- a/lib/slack_logger_backend/logger.ex
+++ b/lib/slack_logger_backend/logger.ex
@@ -88,7 +88,7 @@ defmodule SlackLoggerBackend.Logger do
   end
 
   defp get_env(key, default \\ nil) do
-    Application.get_env(SlackLoggerBackend, key) || Application.get_env(:slack_logger_backend, key) || default
+    Application.get_env(SlackLoggerBackend, key, Application.get_env(:slack_logger_backend, key, default))
   end
 
 end


### PR DESCRIPTION
If not done, latest Elixir version throws this error: 

```
You have configured application SlackLoggerBackend in your configuration
file, but the application is not available.

This usually means one of:

1. You have not added the application as a dependency in a mix.exs file.

2. You are configuring an application that does not really exist.

Please ensure SlackLoggerBackend exists or remove the configuration.
```