### PR TITLE
Allow phoenix logs

### DIFF
--- a/lib/slack_logger_backend/logger.ex
+++ b/lib/slack_logger_backend/logger.ex
@@ -74,6 +74,10 @@ defmodule SlackLoggerBackend.Logger do
     |> send_event
   end
 
+  defp handle_event(level, message, [pid: pid, request_id: _request_id, application: application, module: module, function: function, file: file, line: line]) do
+    handle_event(level, message, [pid: pid, application: application, module: module, function: function, file: file, line: line])
+  end
+
   defp handle_event(level, message, [pid: _, module: module, function: function, file: file, line: line]) do
     {level, message, module, function, file, line}
     |> send_event


### PR DESCRIPTION
Phoenix logs do not go through as they append request_id to metadata.
This patch allows the library to work seamlessly with phoenix projects.

